### PR TITLE
Fix duplicated EnvironmentVariables in plist

### DIFF
--- a/com.things3.sync.plist
+++ b/com.things3.sync.plist
@@ -21,7 +21,8 @@
     
     <key>WorkingDirectory</key>
     <string>$HOME/Development/Things3TodaySync</string>
-    
+
+    <!-- Set environment variables if needed -->
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -44,13 +45,6 @@
     <!-- Ensure clean process management -->
     <key>AbandonProcessGroup</key>
     <true/>
-    
-    <!-- Set environment variables if needed -->
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    </dict>
     
     <!-- Run with low priority -->
     <key>LowPriorityIO</key>


### PR DESCRIPTION
## Summary
- combine redundant `EnvironmentVariables` sections in `com.things3.sync.plist`

## Testing
- `python3 -m py_compile extract_tasks.py`
- `bash -n setup.sh sync_things.sh`


------
https://chatgpt.com/codex/tasks/task_e_684958a493f0832286d8dd969cc6c4b5