### PR TITLE
Fix config defaults and bash syntax

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -22,7 +22,9 @@ REMOTE_CSV="$REMOTE_DIR/today_view.csv" # Where to store the CSV on the server
 
 # Local files
 LOCAL_CSV="today_view.csv"            # Local CSV file with today's tasks
-EXTRACT_SCRIPT="extract_today_tasks_simple.py"  # Script to extract tasks from Things3
+# Path to Things3 database (default for macOS)
+THINGS_DB="$HOME/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-BQ2NY/Things Database.thingsdatabase/main.sqlite"
+EXTRACT_SCRIPT="extract_tasks.py"  # Script to extract tasks from Things3
 LOG_FILE="$SCRIPT_DIR/things_sync.log" # Log file location
 
 # ===== EXPORT VARIABLES =====
@@ -31,4 +33,4 @@ LOG_FILE="$SCRIPT_DIR/things_sync.log" # Log file location
 # Export all variables for use in other scripts
 export EC2_USER EC2_HOST EC2_KEY_PATH \
        REMOTE_DIR REMOTE_CSV \
-       LOCAL_CSV EXTRACT_SCRIPT SCRIPT_DIR LOG_FILE
+       THINGS_DB LOCAL_CSV EXTRACT_SCRIPT SCRIPT_DIR LOG_FILE

--- a/sync_things.sh
+++ b/sync_things.sh
@@ -99,6 +99,9 @@ log() {
             "ERROR")   echo -e "\033[0;31m$log_entry\033[0m" >&2 ;;
             *)          echo "$log_entry" ;;
         esac
+    fi
+}
+
 # Function to test SSH connection
 test_ssh_connection() {
     if ! ssh -q -i "$EC2_KEY_PATH" -o BatchMode=yes -o ConnectTimeout=5 "$EC2_USER@$EC2_HOST" exit; then


### PR DESCRIPTION
## Summary
- set `EXTRACT_SCRIPT` to `extract_tasks.py`
- add `THINGS_DB` variable to example configuration
- fix missing `fi`/`}` in `sync_things.sh`

## Testing
- `bash -n setup.sh`
- `bash -n config.sh.example`
- `bash -n sync_things.sh`
- `shellcheck sync_things.sh`
- `python3 -m py_compile extract_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_684958a135fc8322a5788703e2d7efe9