### PR TITLE
Fix newline at end of extract_tasks.py

### DIFF
--- a/extract_tasks.py
+++ b/extract_tasks.py
@@ -174,4 +174,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
## Summary
- ensure `extract_tasks.py` ends with the canonical `if __name__` block
- add missing newline at end of file

## Testing
- `python3 - <<'EOF'
with open('extract_tasks.py','rb') as f:
    d=f.read()
print(repr(d[-20:]))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684958a2448c83228f938c2e3e5c5e4d