### PR TITLE
Add anytime tasks export

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A lightweight utility to sync your Things3 Today view with a remote server.
 ## Features
 
 - Automatic extraction of Today's tasks from Things3
+- Optional export of Upcoming tasks to ``upcoming_tasks.csv``
+- Optional export of Anytime tasks to ``anytime_tasks.csv``
 - Secure sync to a remote server every minute
 - Detailed logging for monitoring
 - macOS launch agent for continuous operation
@@ -100,6 +102,16 @@ launchctl unload ~/Library/LaunchAgents/com.things3.sync.plist
 Run a single sync operation:
 ```bash
 ./sync_things.sh
+```
+
+Generate ``upcoming_tasks.csv`` manually:
+```bash
+python3 extract_upcoming.py
+```
+
+Generate ``anytime_tasks.csv`` manually:
+```bash
+python3 extract_anytime.py
 ```
 
 ### Logs and Monitoring

--- a/config.sh.example
+++ b/config.sh.example
@@ -21,7 +21,10 @@ REMOTE_CSV="$REMOTE_DIR/today_view.csv" # Where to store the CSV on the server
 # ===== LOCAL SETTINGS =====
 
 # Local files
-LOCAL_CSV="today_view.csv"            # Local CSV file with today's tasks
+# CSV filenames
+LOCAL_CSV="today_view.csv"            # Today's tasks
+UPCOMING_CSV="upcoming_tasks.csv"     # Upcoming tasks
+ANYTIME_CSV="anytime_tasks.csv"       # Anytime tasks
 # Path to Things3 database (default for macOS)
 THINGS_DB="$HOME/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-BQ2NY/Things Database.thingsdatabase/main.sqlite"
 EXTRACT_SCRIPT="extract_tasks.py"  # Script to extract tasks from Things3
@@ -35,4 +38,5 @@ LOG_FILE="$SCRIPT_DIR/things_sync.log" # Log file location
 # Export all variables for use in other scripts
 export EC2_USER EC2_HOST EC2_KEY_PATH \
        REMOTE_DIR REMOTE_CSV \
-       THINGS_DB LOCAL_CSV EXTRACT_SCRIPT GOOGLE_TASKS_SYNC SCRIPT_DIR LOG_FILE
+       THINGS_DB LOCAL_CSV UPCOMING_CSV ANYTIME_CSV \
+       EXTRACT_SCRIPT GOOGLE_TASKS_SYNC SCRIPT_DIR LOG_FILE

--- a/extract_anytime.py
+++ b/extract_anytime.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Extract tasks from the "Anytime" list in Things3 where both the start date and
+``due date`` are not set. The extracted tasks are saved as ``anytime_tasks.csv``
+with the same columns as the other CSV exports.
+"""
+
+import subprocess
+import csv
+import sys
+from typing import List, Dict
+
+
+def runAppleScript(script: str) -> str:
+    """Execute AppleScript and return output."""
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"AppleScript error: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+def getAnytimeTaskCount() -> int:
+    """Get count of tasks in the Anytime list."""
+    script = 'tell application "Things3" to count to dos of list "Anytime"'
+    count_str = runAppleScript(script)
+    return int(count_str)
+
+
+def getTaskProperty(index: int, property_name: str) -> str:
+    """Get a specific property of a task by index."""
+    script = (
+        f'tell application "Things3" to {property_name} of item {index} of to dos of list "Anytime"'
+    )
+    result = runAppleScript(script)
+    if result == "missing value":
+        return ""
+    return result
+
+
+def getTaskTags(index: int) -> str:
+    """Return a semicolon-separated list of tags for the task."""
+    script = f'''
+    tell application "Things3"
+        set theTags to tags of item {index} of to dos of list "Anytime"
+        set tagList to ""
+        repeat with aTag in theTags
+            set tagList to tagList & name of aTag & "; "
+        end repeat
+        return tagList
+    end tell
+    '''
+    tags = runAppleScript(script).strip()
+    if tags.endswith("; "):
+        tags = tags[:-2]
+    return tags
+
+
+def getFormattedDate(index: int, property_name: str) -> str:
+    """Return Things3 date property formatted as YYYY-MM-DD or empty string."""
+    script = f'''
+    tell application "Things3"
+        set theDate to {property_name} of item {index} of to dos of list "Anytime"
+        if theDate is missing value then
+            return ""
+        else
+            set y to year of theDate as integer
+            set m to month of theDate as integer
+            set d to day of theDate as integer
+            return (y as string) & "," & (m as string) & "," & (d as string)
+        end if
+    end tell
+    '''
+    raw_result = runAppleScript(script)
+    if not raw_result:
+        return ""
+    try:
+        y_str, m_str, d_str = [part.strip() for part in raw_result.split(",")]
+        y, m, d = int(y_str), int(m_str), int(d_str)
+        return f"{y:04d}-{m:02d}-{d:02d}"
+    except ValueError:
+        return ""
+
+
+def getTaskDetails(index: int) -> Dict[str, str] | None:
+    """Return a dictionary of task details or ``None`` if the task should be skipped."""
+    title = getTaskProperty(index, "name")
+    notes = getTaskProperty(index, "notes")
+
+    start_date = getFormattedDate(index, "activation date")
+    due_date = getFormattedDate(index, "due date") or getFormattedDate(index, "deadline")
+
+    # Skip tasks that have either a start or due date
+    if start_date or due_date:
+        return None
+
+    project_script = f'''
+    tell application "Things3"
+        set theTask to item {index} of to dos of list "Anytime"
+        if project of theTask is not missing value then
+            return name of project of theTask
+        else
+            return ""
+        end if
+    end tell
+    '''
+    project = runAppleScript(project_script)
+    if not project:
+        project = "None"
+
+    tags = getTaskTags(index)
+
+    return {
+        "title": title,
+        "notes": notes,
+        "project": project,
+        "start_date": start_date,
+        "due_date": due_date,
+        "tags": tags,
+    }
+
+
+def extractAnytimeTasks() -> List[Dict[str, str]]:
+    """Extract tasks from Anytime that lack both start and due dates."""
+    task_count = getAnytimeTaskCount()
+    print(f"Found {task_count} tasks in Anytime")
+
+    tasks: List[Dict[str, str]] = []
+    for i in range(1, task_count + 1):
+        print(f"Processing task {i}/{task_count}...", end="\r")
+        details = getTaskDetails(i)
+        if details:
+            tasks.append(details)
+
+    print()
+    return tasks
+
+
+def writeToCsv(tasks: List[Dict[str, str]], filename: str = "anytime_tasks.csv") -> None:
+    """Write the given tasks to a CSV file."""
+    with open(filename, "w", newline="", encoding="utf-8") as csvfile:
+        fieldnames = ["ItemName", "ItemType", "ResidesWithin", "Notes", "ToDoDate", "DueDate", "Tags"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for task in tasks:
+            notes = task["notes"].replace("\n", " ").replace("\r", " ")
+            row = {
+                "ItemName": '"' + task["title"].replace('"', '""') + '"',
+                "ItemType": '"Task"',
+                "ResidesWithin": '"' + task["project"].replace('"', '""') + '"',
+                "Notes": '"' + notes.replace('"', '""') + '"' if notes else '""',
+                "ToDoDate": '"' + task["start_date"] + '"' if task["start_date"] else '""',
+                "DueDate": '"' + task["due_date"] + '"' if task["due_date"] else '""',
+                "Tags": '"' + task["tags"].replace('"', '""') + '"' if task["tags"] else '""',
+            }
+            writer.writerow(row)
+
+
+def main() -> None:
+    print("Extracting Anytime tasks from Things3...")
+    tasks = extractAnytimeTasks()
+    writeToCsv(tasks)
+    print(f"Successfully wrote {len(tasks)} tasks to anytime_tasks.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/extract_upcoming.py
+++ b/extract_upcoming.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Extract Upcoming tasks from Things3 using AppleScript and save to CSV.
+This version mirrors ``extract_tasks.py`` but targets the ``Upcoming`` list.
+"""
+
+import subprocess
+import csv
+import sys
+from typing import List, Dict
+
+
+def runAppleScript(script: str) -> str:
+    """Execute AppleScript and return output."""
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"AppleScript error: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+
+def getUpcomingTaskCount() -> int:
+    """Get count of tasks in the Upcoming list."""
+    script = 'tell application "Things3" to count to dos of list "Upcoming"'
+    count_str = runAppleScript(script)
+    return int(count_str)
+
+
+def getTaskProperty(index: int, property_name: str) -> str:
+    """Get a specific property of a task by index."""
+    script = f'tell application "Things3" to {property_name} of item {index} of to dos of list "Upcoming"'
+    result = runAppleScript(script)
+    # Handle missing values
+    if result == "missing value":
+        return ""
+    return result
+
+
+def getTaskTags(index: int) -> str:
+    """Get tags for a task."""
+    script = f'''
+    tell application "Things3"
+        set theTags to tags of item {index} of to dos of list "Upcoming"
+        set tagList to ""
+        repeat with aTag in theTags
+            set tagList to tagList & name of aTag & "; "
+        end repeat
+        return tagList
+    end tell
+    '''
+    tags = runAppleScript(script).strip()
+    # Remove trailing "; "
+    if tags.endswith("; "):
+        tags = tags[:-2]
+    return tags
+
+
+def getFormattedDate(index: int, primary_prop: str, fallback_prop: str | None = None) -> str:
+    """Return Things3 date property as YYYY-MM-DD or empty string.
+
+    Uses AppleScript to extract year / month / day components directly so it
+    works regardless of macOS locale.
+    """
+    script = f'''
+    tell application "Things3"
+        set theDate to {primary_prop} of item {index} of to dos of list "Upcoming"
+        if theDate is missing value then
+            return ""
+        else
+            set y to year of theDate as integer
+            set m to month of theDate as integer
+            set d to day of theDate as integer
+            return (y as string) & "," & (m as string) & "," & (d as string)
+        end if
+    end tell
+    '''
+    raw_result = runAppleScript(script)
+    if not raw_result and fallback_prop:
+        # Try fallback AppleScript property
+        script_fallback = script.replace(primary_prop, fallback_prop)
+        raw_result = runAppleScript(script_fallback)
+    if not raw_result:
+        return ""
+    try:
+        y_str, m_str, d_str = [part.strip() for part in raw_result.split(",")]
+        y, m, d = int(y_str), int(m_str), int(d_str)
+        return ("%04d" % y) + "-" + ("%02d" % m) + "-" + ("%02d" % d)
+    except ValueError:
+        return ""
+
+
+def getTaskDetails(index: int) -> Dict[str, str]:
+    """Get all details for a single task."""
+    # Get basic properties
+    title = getTaskProperty(index, "name")
+    notes = getTaskProperty(index, "notes")
+    
+    # Get dates using locale-independent ISO formatting
+    start_date_str = getFormattedDate(index, "activation date")
+    due_date_str = getFormattedDate(index, "due date", "deadline")
+    
+    # Get project
+    project_script = f'''
+    tell application "Things3"
+        set theTask to item {index} of to dos of list "Upcoming"
+        if project of theTask is not missing value then
+            return name of project of theTask
+        else
+            return ""
+        end if
+    end tell
+    '''
+    project = runAppleScript(project_script)
+    if not project:
+        project = "None"
+    
+    # Get tags
+    tags = getTaskTags(index)
+    
+    return {
+        "title": title,
+        "notes": notes,
+        "project": project,
+        "start_date": start_date_str,
+        "due_date": due_date_str,
+        "tags": tags
+    }
+
+
+def extractUpcomingTasks() -> List[Dict[str, str]]:
+    """Extract all tasks from the Upcoming list."""
+    task_count = getUpcomingTaskCount()
+    print(f"Found {task_count} tasks in Upcoming")
+    
+    tasks = []
+    for i in range(1, task_count + 1):
+        print(f"Extracting task {i}/{task_count}...", end="\r")
+        task = getTaskDetails(i)
+        tasks.append(task)
+    
+    print()  # New line after progress
+    return tasks
+
+
+def writeToCsv(tasks: List[Dict[str, str]], filename: str = "upcoming_tasks.csv"):
+    """Write tasks to CSV file in the expected format."""
+    with open(filename, "w", newline="", encoding="utf-8") as csvfile:
+        fieldnames = ["ItemName", "ItemType", "ResidesWithin", "Notes", "ToDoDate", "DueDate", "Tags"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        
+        for task in tasks:
+            # Clean up notes - replace newlines with spaces
+            notes = task["notes"].replace("\n", " ").replace("\r", " ")
+            
+            # Format row with proper escaping
+            row = {
+                "ItemName": '"' + task["title"].replace('"', '""') + '"',
+                "ItemType": '"Task"',
+                "ResidesWithin": '"' + task["project"].replace('"', '""') + '"',
+                "Notes": '"' + notes.replace('"', '""') + '"' if notes else '""',
+                "ToDoDate": '"' + task["start_date"] + '"' if task["start_date"] else '""',
+                "DueDate": '"' + task["due_date"] + '"' if task["due_date"] else '""',
+                "Tags": '"' + task["tags"].replace('"', '""') + '"' if task["tags"] else '""'
+            }
+            writer.writerow(row)
+
+
+def main():
+    """Main function."""
+    print("Extracting Upcoming tasks from Things3...")
+    tasks = extractUpcomingTasks()
+    writeToCsv(tasks)
+    print(f"Successfully wrote {len(tasks)} tasks to upcoming_tasks.csv")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `extract_anytime.py` to export the Anytime list to `anytime_tasks.csv`
- document the new script in the README
- update example config with `ANYTIME_CSV`

## Testing
- `python3 -m py_compile extract_anytime.py extract_upcoming.py extract_tasks.py import_google_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_684a7730a684832285aa6db897f9d00e