### PR TITLE
Fix English-only tasks extraction

### DIFF
--- a/extract_tasks.py
+++ b/extract_tasks.py
@@ -8,7 +8,18 @@ This version uses a simpler approach to avoid AppleScript syntax issues.
 import subprocess
 import csv
 import sys
+import re
 from typing import List, Dict
+
+
+_ENG_LETTER_RE = re.compile(r"[A-Za-z]")
+
+
+def is_pure_english(text: str) -> bool:
+    """Return True if ``text`` contains only ASCII characters and at least
+    one English letter."""
+
+    return bool(text) and text.isascii() and bool(_ENG_LETTER_RE.search(text))
 
 
 def runAppleScript(script: str) -> str:
@@ -143,6 +154,9 @@ def extractTodayTasks() -> List[Dict[str, str]]:
     for i in range(1, task_count + 1):
         print(f"Extracting task {i}/{task_count}...", end="\r")
         task = getTaskDetails(i)
+        if is_pure_english(task["title"]):
+            print(f"Skipping English-only task: {task['title']}")
+            continue
         tasks.append(task)
     
     print()  # New line after progress


### PR DESCRIPTION
## Summary
- ignore English-only tasks in extract_tasks.py so server can handle them

## Testing
- `python3 -m py_compile extract_tasks.py`
- `python3 -m py_compile server/process_english_tasks.py`
- `python3 -m py_compile extract_anytime.py extract_upcoming.py import_google_tasks.py server/process_english_tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_684bcd9ee4b88322ba48a54b86cbc122