### PR TITLE
Maintain last 24h of log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A lightweight utility to sync your Things3 Today view with Google Tasks.
 - Sync with Google Tasks every 10 minutes
 - Local backup of tasks in CSV format
 - Detailed logging for monitoring
+- Automatic log trimming (keeps only the last 24 hours)
 - macOS launch agent for continuous operation
 - Minimal resource usage
 
@@ -111,6 +112,8 @@ Run a single sync operation:
   ```bash
   tail -f sync.log
   ```
+- Old log entries are automatically removed so the file only contains the last
+  24 hours of activity.
   
 - View detailed logs:
   ```bash


### PR DESCRIPTION
## Summary
- trim sync log to the most recent 24 hours
- document automatic log trimming in README

## Testing
- `shellcheck sync_today.sh`
- `python3 -m py_compile extract_tasks.py import_google_tasks.py extract_anytime.py extract_upcoming.py server/process_english_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_684dcd514f408322b0fcb4243c276304