### PR TITLE
Add due time export and dedupe between lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ process tasks from Google Tasks back into Things3.
 - **Two‑way synchronisation** – export from Things3 and import from Google Tasks.
 - **Task extraction** – grab tasks from the *Today*, *Upcoming* and
   *Anytime* lists as CSV files.
+- **Time support** – Today exports now include a `DueTime` column with the
+  task's time in 24‑hour format when available.
 - **Google Tasks integration** – `import_google_tasks.py` keeps your
   Google list aligned with the CSV data.
 - **Server processing** – optional scripts under `server/` pull English

--- a/import_google_tasks.py
+++ b/import_google_tasks.py
@@ -62,8 +62,15 @@ def readTasksFromCsv(filename: str) -> List[Dict[str, Optional[str]]]:
     for _, row in df.iterrows():
         title = str(row.get('ItemName', ''))
         notes = str(row.get('Notes', ''))
-        due_raw = str(row.get('DueDate', ''))
-        due = due_raw + 'T00:00:00.000Z' if due_raw else None
+        due_date = str(row.get('DueDate', ''))
+        due_time = str(row.get('DueTime', '')).strip()
+        if due_date:
+            if due_time and due_time.lower() not in {'nan', 'none'}:
+                due = f"{due_date}T{due_time}:00.000Z"
+            else:
+                due = f"{due_date}T00:00:00.000Z"
+        else:
+            due = None
         tasks.append({'title': title, 'notes': notes, 'due': due})
     return tasks
 


### PR DESCRIPTION
## Summary
- support time extraction for today tasks
- include `DueTime` column in `today_view.csv`
- import script reads time values and sets due datetime
- skip duplicates when exporting upcoming and anytime lists
- document new `DueTime` column

## Testing
- `python3 -m py_compile extract_tasks.py import_google_tasks.py extract_anytime.py extract_upcoming.py`

------
https://chatgpt.com/codex/tasks/task_e_684e682747ec8322aff7ca0f2b6cf9c7